### PR TITLE
Add authentification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,10 +43,23 @@ class App extends Component<void, AppState> {
     app_token: ''
   }
 
+  componentDidMount() {
+    if (document.cookie) {
+      let tokenItem = document.cookie.split(';').filter((item) => item.includes('token='))[0];
+      if (tokenItem) {
+        this.setState({
+          app_token: tokenItem.split('=').pop()
+        })
+      }
+    }
+  }
+
   handleToken = (token: string) => {
     this.setState({
       app_token: token
-    })
+    });
+    // Cookie is set to expire after 30 days
+    document.cookie = 'token=' + token + ';max-age=2592000';
   }
 
   render() {

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,12 @@
+// @flow
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
-import request from 'superagent';
 
 import Datasets from './Datasets';
+import Login from './Login';
 
 import './css/bootstrap-4.1.3.min.css';
 import './css/app.css';
-
-const getToken = async () => {
-  var res = await request.post(process.env.REACT_APP_API_URL + '/authentication/authenticate').send({username: 'admin@test.ode', password: 'password'});
-  return res.body.token;
-}
 
 const Navbar = () => (
   <div className="col-sm-3 border rounded">
@@ -21,7 +17,10 @@ const Navbar = () => (
   </div>
 );
 
-const OdeApp = (props) => (
+type OdeAppProps = {
+  app_token: string
+};
+const OdeApp = (props: OdeAppProps) => (
   <div className="container">
     <div className="row text-center">
       <div className="col-sm-12"><h1>Ocean Data Explorer</h1></div>
@@ -36,19 +35,34 @@ const OdeApp = (props) => (
   </div>
 );
 
-class App extends Component {
+type AppState = {
+  app_token: string
+};
+class App extends Component<void, AppState> {
   state = {
-    app_token: getToken()
+    app_token: ''
+  }
+
+  handleToken = (token: string) => {
+    this.setState({
+      app_token: token
+    })
   }
 
   render() {
-    return (
-      <Router>
-        <Switch>
-          <Route render={() => <OdeApp app_token={this.state.app_token} />} />
-        </Switch>
-      </Router>
-    )
+    if (this.state.app_token) {
+      return (
+        <Router>
+          <Switch>
+            <Route render={() => <OdeApp app_token={this.state.app_token} />} />
+          </Switch>
+        </Router>
+      )
+    } else {
+      return (
+        <Login handleToken={this.handleToken} />
+      )
+    }
   }
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { Component } from 'react';
+import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
+import request from 'superagent';
 
 import Datasets from './Datasets';
 
-import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
-
 import './css/bootstrap-4.1.3.min.css';
 import './css/app.css';
+
+const getToken = async () => {
+  var res = await request.post(process.env.REACT_APP_API_URL + '/authentication/authenticate').send({username: 'admin@test.ode', password: 'password'});
+  return res.body.token;
+}
 
 const Navbar = () => (
   <div className="col-sm-3 border rounded">
@@ -16,7 +21,7 @@ const Navbar = () => (
   </div>
 );
 
-const OdeApp = () => (
+const OdeApp = (props) => (
   <div className="container">
     <div className="row text-center">
       <div className="col-sm-12"><h1>Ocean Data Explorer</h1></div>
@@ -24,19 +29,27 @@ const OdeApp = () => (
     <div className="row text-left h-100 main">
       <Navbar />
       <Switch>
-        <Route exact path='/' component={Datasets} />
-        <Route path='/datasets' component={Datasets} />
+        <Route exact path='/' render={() => <Datasets app_token={props.app_token} />} />
+        <Route path='/datasets' render={() => <Datasets app_token={props.app_token} />} />
       </Switch>
     </div>
   </div>
 );
 
-const App = () => (
-  <Router>
-    <Switch>
-      <Route component={OdeApp} />
-    </Switch>
-  </Router>
-);
+class App extends Component {
+  state = {
+    app_token: getToken()
+  }
+
+  render() {
+    return (
+      <Router>
+        <Switch>
+          <Route render={() => <OdeApp app_token={this.state.app_token} />} />
+        </Switch>
+      </Router>
+    )
+  }
+}
 
 export default App;

--- a/src/Datasets.js
+++ b/src/Datasets.js
@@ -36,6 +36,11 @@ class Datasets extends Component<DatasetsProps, DatasetsState> {
         datasets: req.body
       })
     }).catch(err => {
+      if (err.status && err.status === 401) {
+        // Server returned 401 which means token was revoked
+        document.cookie = 'token=;max-age=0';
+        window.location.reload();
+      }
       this.setState({
         error: err
       })

--- a/src/Datasets.js
+++ b/src/Datasets.js
@@ -1,24 +1,44 @@
+// @flow
 import React, { Component } from 'react';
 import request from 'superagent';
 
-class Datasets extends Component {
-  state = {
-    datasets: []
+if (!process.env.REACT_APP_API_URL) throw new Error('REACT_APP_API_URL missing in env');
+const API_URL = process.env.REACT_APP_API_URL + '/dataset/list';
+
+type DatasetsProps = {
+  app_token: string
+};
+type DatasetsState = {
+  datasets: Array<{
+    id: number,
+    name: string,
+    type: string,
+    files_type: string,
+    files_count: number,
+    start_date: string,
+    end_date: string
+  }>,
+  error: ?{
+    status: number,
+    message: string
   }
-  getData = request.get(process.env.REACT_APP_API_URL + '/dataset/list')
+};
+class Datasets extends Component<DatasetsProps, DatasetsState> {
+  state = {
+    datasets: [],
+    error: null
+  }
+  getData = request.get(API_URL)
 
   componentDidMount() {
-    if (!process.env.REACT_APP_API_URL) throw new Error('REACT_APP_API_URL missing in env');
-    return this.props.app_token.then(token => {
-      return this.getData.set('Authorization', 'Bearer ' + token).then(req => {
-        this.setState({
-          datasets: req.body
-        })
-      }).catch(err => {
-        this.setState({
-          error: err
-        })
-      });
+    return this.getData.set('Authorization', 'Bearer ' + this.props.app_token).then(req => {
+      this.setState({
+        datasets: req.body
+      })
+    }).catch(err => {
+      this.setState({
+        error: err
+      })
     });
   }
 

--- a/src/Datasets.js
+++ b/src/Datasets.js
@@ -9,14 +9,16 @@ class Datasets extends Component {
 
   componentDidMount() {
     if (!process.env.REACT_APP_API_URL) throw new Error('REACT_APP_API_URL missing in env');
-    return this.getData.then(req => {
-      this.setState({
-        datasets: req.body
-      })
-    }).catch(err => {
-      this.setState({
-        error: err
-      })
+    return this.props.app_token.then(token => {
+      return this.getData.set('Authorization', 'Bearer ' + token).then(req => {
+        this.setState({
+          datasets: req.body
+        })
+      }).catch(err => {
+        this.setState({
+          error: err
+        })
+      });
     });
   }
 

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,0 +1,86 @@
+// @flow
+import React, { Component } from 'react';
+import request from 'superagent';
+
+if (!process.env.REACT_APP_API_URL) throw new Error('REACT_APP_API_URL missing in env');
+const API_URL = process.env.REACT_APP_API_URL + '/authentication/authenticate';
+
+type LoginProps = {
+  handleToken: (token: string) => void
+};
+type LoginState = {
+  login: string,
+  password: string,
+  error: ?{
+    status: number,
+    message: string
+  }
+};
+class Login extends Component<LoginProps, LoginState> {
+  state = {
+    login: '',
+    password: '',
+    error: null
+  }
+  sendData = { abort: () => null }
+
+  componentWillUnmount() {
+    this.sendData.abort();
+  }
+
+  handleLoginChange = (event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({login: event.currentTarget.value});
+  }
+
+  handlePasswordChange = (event: SyntheticEvent<HTMLInputElement>) => {
+    this.setState({password: event.currentTarget.value});
+  }
+
+  handleSubmit = (event: SyntheticEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    this.setState({error: null});
+    this.sendData = request.post(API_URL);
+    let loginInfo = {username: this.state.login, password: this.state.password};
+    return this.sendData.send(loginInfo).then(res => {
+      return this.props.handleToken(res.body.token);
+    }).catch(err => {
+      // Checking if this is an HTTP error
+      if (err.status && err.response) {
+        if (err.status === 401) {
+          err.message = 'Access denied'
+        }
+        this.setState({error: err});
+      } else {
+        throw err
+      }
+    })
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <div className="row text-left h-100 main">
+          <div className="col-sm-12 border rounded">
+            <h1 className="text-center">Login</h1>
+            {this.state.error &&
+              <p className="error-message">{this.state.error.message}</p>
+            }
+            <form onSubmit={this.handleSubmit}>
+              <div className="form-group">
+                <label htmlFor="loginInput">Login</label>
+                <input id="loginInput" className="form-control" type="text" value={this.state.login} onChange={this.handleLoginChange} />
+              </div>
+              <div className="form-group">
+                <label htmlFor="passwordInput">Password</label>
+                <input id="passwordInput" className="form-control" type="password" value={this.state.password} onChange={this.handlePasswordChange} />
+              </div>
+              <input className="btn btn-primary" type="submit" value="Submit" />
+            </form>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Login;

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -7,17 +7,27 @@ import Navbar from '../src/App';
 
 describe('testing App component', function () {
     this.timeout(20000);
-    it('mounts properly with Login when token is not there', () => {
-        let wrapper = mount(<App />);
-        assert(wrapper.text().includes('Login'), 'Login not found');
-        wrapper.unmount();
-    });
 
-    it('mounts properly with Navbar when token is there', () => {
+    it('mounts properly with Navbar when token is in state', () => {
         let wrapper = mount(<App />);
         wrapper.setState({app_token: 'testToken'});
         wrapper.update();
         assert(wrapper.find(Navbar).text().includes('Datasets'), 'Navbar linking to datasets not found');
+        wrapper.unmount();
+    });
+
+    it('mounts properly with Navbar when token is in cookie', () => {
+        document.cookie = 'token=testing';
+        let wrapper = mount(<App />);
+        wrapper.update();
+        assert(wrapper.find(Navbar).text().includes('Datasets'), 'Navbar linking to datasets not found');
+        wrapper.unmount();
+        document.cookie = 'token=;max-age=0';
+    });
+
+    it('mounts properly with Login when token is not there', () => {
+        let wrapper = mount(<App />);
+        assert(wrapper.text().includes('Login'), 'Login not found');
         wrapper.unmount();
     });
 });

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -7,8 +7,16 @@ import Navbar from '../src/App';
 
 describe('testing App component', function () {
     this.timeout(20000);
-    it('mounts properly with Navbar', () => {
+    it('mounts properly with Login when token is not there', () => {
         let wrapper = mount(<App />);
+        assert(wrapper.text().includes('Login'), 'Login not found');
+        wrapper.unmount();
+    });
+
+    it('mounts properly with Navbar when token is there', () => {
+        let wrapper = mount(<App />);
+        wrapper.setState({app_token: 'testToken'});
+        wrapper.update();
         assert(wrapper.find(Navbar).text().includes('Datasets'), 'Navbar linking to datasets not found');
         wrapper.unmount();
     });

--- a/test/Login.test.js
+++ b/test/Login.test.js
@@ -1,0 +1,67 @@
+import assert from 'assert';
+import React from 'react';
+import nock from 'nock';
+import { mount, shallow } from 'enzyme';
+
+import Login from '../src/Login';
+
+describe('testing Login component', function () {
+    this.timeout(20000);
+
+    it('mounts properly with title', () => {
+        let wrapper = mount(<Login />);
+        assert(wrapper.text().includes('Login'), 'Title "Login" not found');
+        wrapper.unmount();
+    });
+
+    it('correctly use handleToken prop for 200 response', () => {
+        nock(process.env.REACT_APP_API_URL).post('/authentication/authenticate').reply(200, {token: 'TestToken'});
+        let token = '';
+        let handleToken = (t) => { token = t };
+        let wrapper = shallow(<Login handleToken={handleToken} />);
+        return wrapper.instance().handleSubmit({preventDefault: () => null}).then(() => {
+            assert.deepEqual(token, 'TestToken', "The token hasn't been set to the correct value");
+            wrapper.unmount();
+        });
+    });
+
+    it('correctly sets error message for 401 response', () => {
+        nock(process.env.REACT_APP_API_URL).post('/authentication/authenticate').reply(401);
+        let wrapper = shallow(<Login />);
+        return wrapper.instance().handleSubmit({preventDefault: () => null}).then(() => {
+            assert.deepEqual(wrapper.state('error').message, 'Access denied', "Error message isn't correct");
+            wrapper.unmount();
+        });
+    });
+
+    it('sends default error message for 400 response', () => {
+        nock(process.env.REACT_APP_API_URL).post('/authentication/authenticate').reply(400);
+        let wrapper = shallow(<Login />);
+        return wrapper.instance().handleSubmit({preventDefault: () => null}).then(() => {
+            assert.deepEqual(wrapper.state('error').message, 'Bad Request', "Error message isn't correct");
+            wrapper.unmount();
+        });
+    });
+
+    it('correctly shows error messages', () => {
+        let wrapper = shallow(<Login />);
+        wrapper.setState( {error: { message: 'Testing Error Message' } });
+        let errorMSG = wrapper.find('p.error-message').first();
+        assert.deepEqual(errorMSG.text(), 'Testing Error Message', "Doesn't show correct error message");
+        wrapper.unmount();
+    });
+
+    it('works when re-submitting after an error', () => {
+        nock(process.env.REACT_APP_API_URL).post('/authentication/authenticate').reply(401);
+        nock(process.env.REACT_APP_API_URL).post('/authentication/authenticate').reply(200);
+        let handleToken = () => { return 'it works' };
+        let wrapper = shallow(<Login handleToken={handleToken} />);
+        return wrapper.instance().handleSubmit({preventDefault: () => null}).then(() => {
+            assert.notDeepEqual(wrapper.state('error'), null, "There should be an error");
+            return wrapper.instance().handleSubmit({preventDefault: () => null})
+        }).then(res => {
+            assert.deepEqual(res, 'it works', "We should get the result of handleToken");
+            wrapper.unmount();
+        });
+    });
+});


### PR DESCRIPTION
FrontApp will need a token for most of FeatureService API calls, this token is set through a login page both as a state and in cookie. The cookie serves in case the page is refreshed (proposed cookie max-age is 30 days).

Login can be tested with FeatureService and for example with `admin@test.ode / password`.

Token validity can be tested by adding the following patch to FeatureService:
```diff
diff --git a/v1/dataset.yaml b/v1/dataset.yaml
index e141cd1..be888af 100644
--- a/v1/dataset.yaml
+++ b/v1/dataset.yaml
@@ -51,6 +51,12 @@ paths:
           schema:
             $ref: '#/definitions/problem'
       x-request-handler:
+        - verify_token:
+            request:
+              uri: /{domain}/sys/authentication/verify-token
+              headers: '{{request.headers}}'
+            return_if:
+              status: ['4xx', '5xx']
         - get_from_backend:
             request:
               uri: /{domain}/sys/dataset/list
```
Then changing the token value in your browser's cookie (after having logged in) and reloading you can see that the dataset-list request doesn't work anymore.